### PR TITLE
migrate from urfave/cli v2 to v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gopasspw/gopass v1.16.1
 	github.com/kjk/lzmadec v0.0.0-20210713164611-19ac3ee91a71
 	github.com/stretchr/testify v1.11.1
-	github.com/urfave/cli/v2 v2.27.7
+	github.com/urfave/cli/v3 v3.9.0
 )
 
 require (
@@ -26,7 +26,6 @@ require (
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/godbus/dbus/v5 v5.2.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/gopasspw/clipboard v0.0.4 // indirect
 	github.com/gopasspw/gitconfig v0.0.3 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/kr/text v0.2.0 // indirect
@@ -35,6 +34,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/twpayne/go-pinentry/v4 v4.0.0 // indirect
+	github.com/urfave/cli/v2 v2.27.7 // indirect
 	github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 // indirect
 	github.com/zalando/go-keyring v0.2.6 // indirect
 	golang.org/x/crypto v0.46.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/twpayne/go-pinentry/v4 v4.0.0 h1:8WcNa+UDVRzz7y9OEEU/nRMX+UGFPCAvl5Xs
 github.com/twpayne/go-pinentry/v4 v4.0.0/go.mod h1:aXvy+awVXqdH+GS0ddQ7AKHZ3tXM6fJ2NK+e16p47PI=
 github.com/urfave/cli/v2 v2.27.7 h1:bH59vdhbjLv3LAvIu6gd0usJHgoTTPhCFib8qqOwXYU=
 github.com/urfave/cli/v2 v2.27.7/go.mod h1:CyNAG/xg+iAOg0N4MPGZqVmv2rCoP267496AOXUZjA4=
+github.com/urfave/cli/v3 v3.9.0 h1:AV9lIiPv3ukYnxunaCUsHnEozptYmDN2F0+yWqLMn/c=
+github.com/urfave/cli/v3 v3.9.0/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 h1:FnBeRrxr7OU4VvAzt5X7s6266i6cSVkkFPS0TuXWbIg=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/zalando/go-keyring v0.2.6 h1:r7Yc3+H+Ux0+M72zacZoItR3UDxeWfKTcabvkI8ua9s=

--- a/hibp_test.go
+++ b/hibp_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"compress/gzip"
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -15,9 +14,7 @@ import (
 	hibpapi "github.com/gopasspw/gopass-hibp/pkg/hibp/api"
 	"github.com/gopasspw/gopass/pkg/ctxutil"
 	"github.com/gopasspw/gopass/pkg/gopass/apimock"
-	"github.com/gopasspw/gopass/tests/gptest"
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v2"
 )
 
 const testHibpSample = `000000005AD76BD555C1D6D771DE417A4B87E4B4
@@ -41,41 +38,17 @@ func TestHIBPDump(t *testing.T) {
 		gp: apimock.New(),
 	}
 
-	app := cli.NewApp()
-	fs := flag.NewFlagSet("default", flag.ContinueOnError)
-	c := cli.NewContext(app, fs, nil)
-	c.Context = ctx
-
 	// setup file and env
 	fn := filepath.Join(dir, "dump.txt")
-	fs = flag.NewFlagSet("default", flag.ContinueOnError)
-	bf := cli.StringSliceFlag{
-		Name:  "dumps",
-		Usage: "dumps",
-	}
-	require.NoError(t, bf.Apply(fs))
-	require.NoError(t, fs.Parse([]string{"--dumps=" + fn}))
-	c = cli.NewContext(app, fs, nil)
-	c.Context = ctx
 
 	require.NoError(t, ioutil.WriteFile(fn, []byte(testHibpSample), 0o644))
-	require.NoError(t, act.CheckDump(c.Context, false, []string{fn}))
+	require.NoError(t, act.CheckDump(ctx, false, []string{fn}))
 
 	// gzip
 	fn = filepath.Join(dir, "dump.txt.gz")
-	fs = flag.NewFlagSet("default", flag.ContinueOnError)
-	bf = cli.StringSliceFlag{
-		Name:  "dumps",
-		Usage: "dumps",
-	}
-	require.NoError(t, bf.Apply(fs))
-	require.NoError(t, fs.Parse([]string{"--dumps=" + fn}))
-
-	c = cli.NewContext(app, fs, nil)
-	c.Context = ctx
 
 	require.NoError(t, testWriteGZ(fn, []byte(testHibpSample)))
-	require.NoError(t, act.CheckDump(c.Context, false, []string{fn}))
+	require.NoError(t, act.CheckDump(ctx, false, []string{fn}))
 }
 
 func testWriteGZ(fn string, buf []byte) error {
@@ -105,8 +78,6 @@ func TestHIBPAPI(t *testing.T) {
 		gp: apimock.New(),
 	}
 
-	c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"api": "true"})
-
 	reqCnt := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		reqCnt++
@@ -130,9 +101,9 @@ func TestHIBPAPI(t *testing.T) {
 	hibpapi.URL = ts.URL
 
 	// test with one entry
-	require.NoError(t, act.CheckAPI(c.Context, false))
+	require.NoError(t, act.CheckAPI(ctx, false))
 
 	// add another one
 	require.NoError(t, act.gp.Set(ctx, "baz", &apimock.Secret{Buf: []byte("foobar")}))
-	require.Error(t, act.CheckAPI(c.Context, false))
+	require.Error(t, act.CheckAPI(ctx, false))
 }

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	hapi "github.com/gopasspw/gopass-hibp/pkg/hibp/api"
 	hibpdump "github.com/gopasspw/gopass-hibp/pkg/hibp/dump"
 	"github.com/gopasspw/gopass/pkg/gopass/api"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 )
 
 const (
@@ -49,107 +49,108 @@ func main() {
 		gp: gp,
 	}
 
-	app := cli.NewApp()
-	app.Name = name
-	app.Version = getVersion().String()
-	app.Usage = "haveibeenpwned.com leak checker for gopass"
-	app.EnableBashCompletion = true
-	app.Commands = []*cli.Command{
-		{
-			Name:  "api",
-			Usage: "Detect leaked passwords using the HIBPv2 API",
-			Description: "" +
-				"This command will decrypt all secrets and check the passwords against the public " +
-				"havibeenpwned.com v2 API.",
-			Action: func(c *cli.Context) error {
-				return hibp.CheckAPI(c.Context, c.Bool("force"))
-			},
-			Flags: []cli.Flag{
-				&cli.BoolFlag{
-					Name:    "force",
-					Aliases: []string{"f"},
-					Usage:   "Force checking secrets against the public API",
+	app := &cli.Command{
+		Name:                  name,
+		Version:               getVersion().String(),
+		Usage:                 "haveibeenpwned.com leak checker for gopass",
+		EnableShellCompletion: true,
+		Commands: []*cli.Command{
+			{
+				Name:  "api",
+				Usage: "Detect leaked passwords using the HIBPv2 API",
+				Description: "" +
+					"This command will decrypt all secrets and check the passwords against the public " +
+					"havibeenpwned.com v2 API.",
+				Action: func(ctx context.Context, cmd *cli.Command) error {
+					return hibp.CheckAPI(ctx, cmd.Bool("force"))
+				},
+				Flags: []cli.Flag{
+					&cli.BoolFlag{
+						Name:    "force",
+						Aliases: []string{"f"},
+						Usage:   "Force checking secrets against the public API",
+					},
 				},
 			},
-		},
-		{
-			Name:  "dump",
-			Usage: "Detect leaked passwords using the HIBP SHA-1 dumps",
-			Description: "" +
-				"This command will decrypt all secrets and check the passwords against the " +
-				"havibeenpwned.com SHA-1 dumps (ordered by hash). " +
-				"To use the dumps you need to download the dumps from https://haveibeenpwned.com/passwords first. Be sure to grab the one that says '(ordered by hash)'. " +
-				"This is a very expensive operation, for advanced users. " +
-				"Most users should probably use the API. " +
-				"If you want to use the dumps you need to use 7z to extract the dump: 7z x pwned-passwords-ordered-2.0.txt.7z.",
-			Action: func(c *cli.Context) error {
-				return hibp.CheckDump(c.Context, c.Bool("force"), c.StringSlice("files"))
-			},
-			Flags: []cli.Flag{
-				&cli.BoolFlag{
-					Name:    "force",
-					Aliases: []string{"f"},
-					Usage:   "Force checking secrets against the dumps",
+			{
+				Name:  "dump",
+				Usage: "Detect leaked passwords using the HIBP SHA-1 dumps",
+				Description: "" +
+					"This command will decrypt all secrets and check the passwords against the " +
+					"havibeenpwned.com SHA-1 dumps (ordered by hash). " +
+					"To use the dumps you need to download the dumps from https://haveibeenpwned.com/passwords first. Be sure to grab the one that says '(ordered by hash)'. " +
+					"This is a very expensive operation, for advanced users. " +
+					"Most users should probably use the API. " +
+					"If you want to use the dumps you need to use 7z to extract the dump: 7z x pwned-passwords-ordered-2.0.txt.7z.",
+				Action: func(ctx context.Context, cmd *cli.Command) error {
+					return hibp.CheckDump(ctx, cmd.Bool("force"), cmd.StringSlice("files"))
 				},
-				&cli.StringSliceFlag{
-					Name:  "files",
-					Usage: "One or more HIBP v1/v2 dumps",
-				},
-			},
-		},
-		{
-			Name:  "download",
-			Usage: "Download HIBP dumps from the v2 API",
-			Action: func(c *cli.Context) error {
-				return hapi.Download(c.Context, c.String("output"), c.Bool("keep"))
-			},
-			Flags: []cli.Flag{
-				&cli.StringFlag{
-					Name:    "output",
-					Aliases: []string{"f"},
-					Usage:   "Output location",
-				},
-				&cli.BoolFlag{
-					Name:    "keep",
-					Aliases: []string{"k"},
-					Usage:   "Keep and re-use partial downloads",
+				Flags: []cli.Flag{
+					&cli.BoolFlag{
+						Name:    "force",
+						Aliases: []string{"f"},
+						Usage:   "Force checking secrets against the dumps",
+					},
+					&cli.StringSliceFlag{
+						Name:  "files",
+						Usage: "One or more HIBP v1/v2 dumps",
+					},
 				},
 			},
-		},
-		{
-			Name:  "merge",
-			Usage: "Merge different dumps",
-			Action: func(c *cli.Context) error {
-				scanner, err := hibpdump.New(c.StringSlice("files")...)
-				if err != nil {
-					return err
-				}
+			{
+				Name:  "download",
+				Usage: "Download HIBP dumps from the v2 API",
+				Action: func(ctx context.Context, cmd *cli.Command) error {
+					return hapi.Download(ctx, cmd.String("output"), cmd.Bool("keep"))
+				},
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:    "output",
+						Aliases: []string{"f"},
+						Usage:   "Output location",
+					},
+					&cli.BoolFlag{
+						Name:    "keep",
+						Aliases: []string{"k"},
+						Usage:   "Keep and re-use partial downloads",
+					},
+				},
+			},
+			{
+				Name:  "merge",
+				Usage: "Merge different dumps",
+				Action: func(ctx context.Context, cmd *cli.Command) error {
+					scanner, err := hibpdump.New(cmd.StringSlice("files")...)
+					if err != nil {
+						return err
+					}
 
-				return scanner.Merge(ctx, c.String("output"))
-			},
-			Flags: []cli.Flag{
-				&cli.StringSliceFlag{
-					Name:  "files",
-					Usage: "One or more HIBP v1/v2 dumps",
+					return scanner.Merge(ctx, cmd.String("output"))
 				},
-				&cli.StringFlag{
-					Name:    "output",
-					Aliases: []string{"f"},
-					Usage:   "Output location",
+				Flags: []cli.Flag{
+					&cli.StringSliceFlag{
+						Name:  "files",
+						Usage: "One or more HIBP v1/v2 dumps",
+					},
+					&cli.StringFlag{
+						Name:    "output",
+						Aliases: []string{"f"},
+						Usage:   "Output location",
+					},
 				},
 			},
-		},
-		{
-			Name: "version",
-			Action: func(c *cli.Context) error {
-				cli.VersionPrinter(c)
+			{
+				Name: "version",
+				Action: func(_ context.Context, cmd *cli.Command) error {
+					cli.VersionPrinter(cmd)
 
-				return nil
+					return nil
+				},
 			},
 		},
 	}
 
-	if err := app.RunContext(ctx, os.Args); err != nil {
+	if err := app.Run(ctx, os.Args); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
- Update import path from github.com/urfave/cli/v2 to github.com/urfave/cli/v3
- Replace cli.NewApp() with &cli.Command{} struct literal
- Replace EnableBashCompletion with EnableShellCompletion
- Update all action functions from func(*cli.Context) error to func(context.Context, *cli.Command) error
- Replace c.Context/c.Bool/c.String/c.StringSlice with ctx/cmd.Bool/etc.
- Replace app.RunContext with cmd.Run (v3 Run takes context directly)
- Simplify tests: remove cli.NewApp/NewContext/flag.NewFlagSet boilerplate, pass context directly to CheckAPI and CheckDump